### PR TITLE
Correct the spelling of retrieve in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Retriver
-Retrive InfoPlist without Jailbreak on iOS Devices
+Retrieve InfoPlist without Jailbreak on iOS Devices
 
 # Usage
 1. Build & Run this project on your iOS Device


### PR DESCRIPTION
This pull request corrects a typo
http://www.dictionary.com/browse/retrieve

Created with [`readme-correct`](https://github.com/dkhamsing/readme-correct).
